### PR TITLE
fix: index.jsp (사진 맵핑, 하드코딩 제거)

### DIFF
--- a/src/main/java/com/grepp/spring/IndexController.java
+++ b/src/main/java/com/grepp/spring/IndexController.java
@@ -1,15 +1,27 @@
 package com.grepp.spring;
 
+import com.grepp.spring.app.model.product.ProductService;
+import com.grepp.spring.app.model.product.dto.ProductDto;
+import java.util.List;
 import org.springframework.stereotype.Controller;
 
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequestMapping("/")
 public class IndexController {
-    @GetMapping
-    public String index() {
+    private final ProductService productService;
+
+    public IndexController(ProductService productService) {
+        this.productService = productService;
+    }
+
+    @GetMapping("/")
+    public String index(Model model) {
+        List<ProductDto> products = productService.getAllProducts();
+        model.addAttribute("products", products);
         return "index";
     }
 }

--- a/src/main/webapp/WEB-INF/view/index.jsp
+++ b/src/main/webapp/WEB-INF/view/index.jsp
@@ -8,66 +8,34 @@
 <body>
 <%@include file="/WEB-INF/view/include/header.jsp" %>
 <%@include file="/WEB-INF/view/include/sidenav.jsp" %>
+
 <main class="container">
-<c:if test="${not empty param.error}">
-    <div class="card-panel red lighten-2 text-white">${param.error}</div>
-</c:if>
-<h4>메인 페이지 : 커피콩 판매 합니다~~~  </h4>
+    <c:if test="${not empty param.error}">
+        <div class="card-panel red lighten-2 text-white">${param.error}</div>
+    </c:if>
+
+    <h4 style="text-align: center;">“We sell fresh coffee beans.”</h4>
     <div class="row">
-        <div class="col s6 m3">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/assets/images/${product.productImgUrl}" style="width: 247px; height: 160px;">
-                    <span class="card-title">Card Title</span>
-                </div>
-                <div class="card-content">
-                    <p>상품명</p><hr>
-                    <p>상품 설명</p>
-                </div>
-            </div>
-        </div>
-        <div class="col s6 m3">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/assets/images/${product.productImgUrl}" style="width: 247px; height: 160px;">
-                    <span class="card-title">Card Title</span>
-                </div>
-                <div class="card-content">
-                    <p>상품명</p><hr>
-                    <p>상품 설명</p>
+        <c:forEach var="product" items="${products}">
+            <div class="col s4 m3">
+                <div class="card" style="text-align: center;">
+                    <div class="card-image" style="text-align: center;">
+                        <img src="/assets/images/${product.productImgUrl}"
+                             style="width: 247px; height: 160px;">
+                    </div>
+                    <div class="card-content" style="text-align: center;">
+                        <p>${product.productName}</p>
+                        <hr>
+                        <p>${product.category}</p>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="col s6 m3">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/assets/images/${product.productImgUrl}" style="width: 247px; height: 160px;">
-                    <span class="card-title">Card Title</span>
-                </div>
-                <div class="card-content">
-                    <p>상품명</p><hr>
-                    <p>상품 설명</p>
-                </div>
-            </div>
-        </div>
-        <div class="col s6 m3">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/assets/images/${product.productImgUrl}" style="width: 247px; height: 160px;">
-                    <span class="card-title">Card Title</span>
-                </div>
-                <div class="card-content">
-                    <p>상품명</p><hr>
-                    <p>상품 설명</p>
-                </div>
-            </div>
-        </div>
+        </c:forEach>
     </div>
 
     <div style="display: flex; justify-content: center; align-items: center; height: 10vh;">
-        <button>구매하기</button>
+        <button class="waves-effect waves-light btn-brown">구매하기</button>
     </div>
-
 
 
 </main>


### PR DESCRIPTION
order.jsp에서 아래 방법으로 사진 띄우도록 했는데, 
재실행할때마다 인덱스 사진안뜨는게 좀그래서 공수도 별로안들고 해서 인덱스에도 적용해봤습니다.

assets/images/sample-1.jpeg 
위 경로에 사진이 들어있으면 잘 뜹니다.
![image](https://github.com/user-attachments/assets/23ed80ce-6616-4890-a169-19bfeb245fcb)
